### PR TITLE
remove deprecated dependency in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "@types/react-router-dom": "^4.0.4",
     "@types/react-router-redux": "^5.0.1",
     "@types/rebass": "^0.2.17",
-    "@types/redux": "^3.6.0",
     "@types/redux-recycle": "^1.2.0",
     "@types/webpack": "^2.2.15",
     "@types/webpack-dev-server": "^2.4.0",


### PR DESCRIPTION
```npm WARN deprecated @types/redux@3.6.0: This is a stub types definition for Redux (https://github.com/reactjs/redux). Redux provides its own type definitions, so you don't need @types/redux installed!```